### PR TITLE
If 'data' does not exist, return empty instead of writing to file

### DIFF
--- a/expipe/backends/filesystem.py
+++ b/expipe/backends/filesystem.py
@@ -280,8 +280,6 @@ class FileSystemAction:
             project = project.parent
         self._attribute_manager = FileSystemObject(path / "attributes.yaml")
         self._data_manager = FileSystemYamlManager(path / "attributes.yaml")
-        if 'data' not in self._data_manager:
-            self._data_manager['data'] = {}
         self._message_manager = FileSystemObjectManager(
             path / "messages", Message, FileSystemMessage, has_attributes=False)
         self._module_manager = FileSystemObjectManager(
@@ -307,6 +305,9 @@ class FileSystemAction:
 
     @property
     def data(self):
+        if not 'data' in self._data_manager:
+            return {}
+
         return self._data_manager['data']
 
 

--- a/expipe/backends/filesystem.py
+++ b/expipe/backends/filesystem.py
@@ -208,7 +208,7 @@ class FileSystemYamlManager(AbstractObjectManager):
         return result.keys()
 
     def __iter__(self):
-        for key in self.keys():
+        for key in self.contents:
             yield key
 
     def __len__(self):

--- a/expipe/core.py
+++ b/expipe/core.py
@@ -589,6 +589,8 @@ class PropertyList:
 
     def __contains__(self, value):
         value = self.dtype_manager(value)
+        if not self.data:
+            return False
         return value in self.data
 
     def __str__(self):


### PR DESCRIPTION
The data property was written even when actions were only read,
which means that we write when the user doesn't expect the attributes
to change. With this change, we instead catch missing data fields when 
reading.