### PR TITLE
Add data_path to Action

### DIFF
--- a/expipe/backends/filesystem.py
+++ b/expipe/backends/filesystem.py
@@ -280,8 +280,6 @@ class FileSystemAction:
             project = project.parent
         self._attribute_manager = FileSystemObject(path / "attributes.yaml")
         self._data_manager = FileSystemYamlManager(path / "attributes.yaml")
-        if 'data' not in self._data_manager:
-            self._data_manager['data'] = {}
         self._message_manager = FileSystemObjectManager(
             path / "messages", Message, FileSystemMessage, has_attributes=False)
         self._module_manager = FileSystemObjectManager(
@@ -307,6 +305,9 @@ class FileSystemAction:
 
     @property
     def data(self):
+        if not 'data' in self._data_manager:
+            return {}
+
         return self._data_manager['data']
 
 

--- a/expipe/backends/filesystem.py
+++ b/expipe/backends/filesystem.py
@@ -292,6 +292,7 @@ class FileSystemAction:
         project = self.path.parent
         if project.stem == 'actions': #TODO consider making project path global
             project = project.parent
+        self._project_path = project
         self._attribute_manager = FileSystemObject(path / "attributes.yaml")
         self._data_manager = FileSystemYamlManager(path / "attributes.yaml")
         self._message_manager = FileSystemObjectManager(
@@ -320,6 +321,9 @@ class FileSystemAction:
     @property
     def data(self):
         return self._data_manager.get('data', {})
+
+    def data_path(self, key):
+        return self.path / "data" / self.data[key]
 
 
 class FileSystemEntity:

--- a/expipe/backends/filesystem.py
+++ b/expipe/backends/filesystem.py
@@ -208,7 +208,7 @@ class FileSystemYamlManager(AbstractObjectManager):
         return result.keys()
 
     def __iter__(self):
-        for key in self.keys():
+        for key in self.contents:
             yield key
 
     def __len__(self):

--- a/expipe/core.py
+++ b/expipe/core.py
@@ -589,6 +589,8 @@ class PropertyList:
 
     def __contains__(self, value):
         value = self.dtype_manager(value)
+        if not self.data:
+            return False
         return value in self.data
 
     def __str__(self):

--- a/expipe/core.py
+++ b/expipe/core.py
@@ -498,6 +498,9 @@ class Action(ExpipeSubObject):
     def data(self):
         return MapManager(self._backend.data)
 
+    def data_path(self, key):
+        return self._backend.data_path(key)
+
 
 class Module(MapManager):
     """


### PR DESCRIPTION
This allows the backend to determine a way to access a given path. The implementation will be backend-specific. This introduces a simple implementation for the filesystem backend which appends `action.data[name]` to the path of the 'data' folder of the action.