### PR TITLE
Create data folder when calling data_path

### DIFF
--- a/expipe/backends/filesystem.py
+++ b/expipe/backends/filesystem.py
@@ -323,6 +323,7 @@ class FileSystemAction:
         return self._data_manager.get('data', {})
 
     def data_path(self, key):
+        (self.path / "data").mkdir(exist_ok=True)
         return self.path / "data" / self.data[key]
 
 


### PR DESCRIPTION
When calling data_path the data folder should exist, and is therefore created if nonexisting